### PR TITLE
add time slots

### DIFF
--- a/src/components/stations/TimeSlotManager.tsx
+++ b/src/components/stations/TimeSlotManager.tsx
@@ -17,14 +17,14 @@ export interface TimeSlot {
 }
 
 interface TimeSlotManagerProps {
-  chargers: Charger[];
-  slots: TimeSlot[];
-  onAddSlot: (slot: Omit<TimeSlot, "id">) => void;
-  onRemoveSlot: (slotId: string) => void;
-  onToggleAvailability: (slotId: string) => void;
+  readonly chargers: readonly Charger[];
+  readonly slots: readonly TimeSlot[];
+  readonly onAddSlot: (slot: Omit<TimeSlot, "id">) => void;
+  readonly onRemoveSlot: (slotId: string) => void;
+  readonly onToggleAvailability: (slotId: string) => void;
 }
 
-export function TimeSlotManager({ chargers, slots, onAddSlot, onRemoveSlot, onToggleAvailability }: TimeSlotManagerProps) {
+export function TimeSlotManager({ chargers, slots, onAddSlot, onRemoveSlot, onToggleAvailability }: Readonly<TimeSlotManagerProps>) {
   const [newStartTime, setNewStartTime] = useState("09:00");
   const [newEndTime, setNewEndTime] = useState("10:00");
   const [selectedChargerId, setSelectedChargerId] = useState<string>("");

--- a/src/components/stations/TimeSlotManager.tsx
+++ b/src/components/stations/TimeSlotManager.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { PlusIcon, Trash2 } from "lucide-react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Card, CardContent } from "@/components/ui/card";
+import { Trash2 } from "lucide-react";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import type { Charger } from "../../contexts/ChargersContext";
 
@@ -19,79 +17,14 @@ export interface TimeSlot {
 interface TimeSlotManagerProps {
   readonly chargers: readonly Charger[];
   readonly slots: readonly TimeSlot[];
-  readonly onAddSlot: (slot: Omit<TimeSlot, "id">) => void;
+  readonly onAddSlot?: (slot: Omit<TimeSlot, "id">) => void;
   readonly onRemoveSlot: (slotId: string) => void;
   readonly onToggleAvailability: (slotId: string) => void;
 }
 
 export function TimeSlotManager({ chargers, slots, onAddSlot, onRemoveSlot, onToggleAvailability }: Readonly<TimeSlotManagerProps>) {
-  const [newStartTime, setNewStartTime] = useState("09:00");
-  const [newEndTime, setNewEndTime] = useState("10:00");
-  const [selectedChargerId, setSelectedChargerId] = useState<string>("");
-
-  const handleAddSlot = () => {
-    if (!selectedChargerId) return;
-    
-    onAddSlot({
-      chargerId: Number(selectedChargerId),
-      startTime: newStartTime,
-      endTime: newEndTime,
-      isAvailable: true,
-    });
-    // Reset to default values
-    setNewStartTime("09:00");
-    setNewEndTime("10:00");
-  };
-
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Add New Time Slot</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex gap-4 items-end">
-            <div className="space-y-2">
-              <Label htmlFor="charger">Charger</Label>
-              <Select value={selectedChargerId} onValueChange={setSelectedChargerId}>
-                <SelectTrigger className="w-[200px]">
-                  <SelectValue placeholder="Select a charger" />
-                </SelectTrigger>
-                <SelectContent>
-                  {chargers.map((charger) => (
-                    <SelectItem key={charger.id} value={charger.id.toString()}>
-                      Charger {charger.id} - {charger.type}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="startTime">Start Time</Label>
-              <Input
-                id="startTime"
-                type="time"
-                value={newStartTime}
-                onChange={(e) => setNewStartTime(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="endTime">End Time</Label>
-              <Input
-                id="endTime"
-                type="time"
-                value={newEndTime}
-                onChange={(e) => setNewEndTime(e.target.value)}
-              />
-            </div>
-            <Button onClick={handleAddSlot} disabled={!selectedChargerId}>
-              <PlusIcon className="h-4 w-4 mr-2" />
-              Add Slot
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
       <Accordion type="single" collapsible className="w-full">
         {chargers.map((charger) => {
           const chargerSlots = slots.filter(slot => slot.chargerId === charger.id);

--- a/src/components/stations/TimeSlotManager.tsx
+++ b/src/components/stations/TimeSlotManager.tsx
@@ -22,7 +22,7 @@ interface TimeSlotManagerProps {
   readonly onToggleAvailability: (slotId: string) => void;
 }
 
-export function TimeSlotManager({ chargers, slots, onAddSlot, onRemoveSlot, onToggleAvailability }: Readonly<TimeSlotManagerProps>) {
+export function TimeSlotManager({ chargers, slots, onRemoveSlot, onToggleAvailability }: Readonly<TimeSlotManagerProps>) {
   return (
     <div className="space-y-6">
       <Accordion type="single" collapsible className="w-full">

--- a/src/components/stations/TimeSlotManager.tsx
+++ b/src/components/stations/TimeSlotManager.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PlusIcon, Trash2 } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import type { Charger } from "../../contexts/ChargersContext";
+
+export interface TimeSlot {
+  id: string;
+  chargerId: number;
+  startTime: string;
+  endTime: string;
+  isAvailable: boolean;
+}
+
+interface TimeSlotManagerProps {
+  chargers: Charger[];
+  slots: TimeSlot[];
+  onAddSlot: (slot: Omit<TimeSlot, "id">) => void;
+  onRemoveSlot: (slotId: string) => void;
+  onToggleAvailability: (slotId: string) => void;
+}
+
+export function TimeSlotManager({ chargers, slots, onAddSlot, onRemoveSlot, onToggleAvailability }: TimeSlotManagerProps) {
+  const [newStartTime, setNewStartTime] = useState("09:00");
+  const [newEndTime, setNewEndTime] = useState("10:00");
+  const [selectedChargerId, setSelectedChargerId] = useState<string>("");
+
+  const handleAddSlot = () => {
+    if (!selectedChargerId) return;
+    
+    onAddSlot({
+      chargerId: Number(selectedChargerId),
+      startTime: newStartTime,
+      endTime: newEndTime,
+      isAvailable: true,
+    });
+    // Reset to default values
+    setNewStartTime("09:00");
+    setNewEndTime("10:00");
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add New Time Slot</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4 items-end">
+            <div className="space-y-2">
+              <Label htmlFor="charger">Charger</Label>
+              <Select value={selectedChargerId} onValueChange={setSelectedChargerId}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue placeholder="Select a charger" />
+                </SelectTrigger>
+                <SelectContent>
+                  {chargers.map((charger) => (
+                    <SelectItem key={charger.id} value={charger.id.toString()}>
+                      Charger {charger.id} - {charger.type}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="startTime">Start Time</Label>
+              <Input
+                id="startTime"
+                type="time"
+                value={newStartTime}
+                onChange={(e) => setNewStartTime(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="endTime">End Time</Label>
+              <Input
+                id="endTime"
+                type="time"
+                value={newEndTime}
+                onChange={(e) => setNewEndTime(e.target.value)}
+              />
+            </div>
+            <Button onClick={handleAddSlot} disabled={!selectedChargerId}>
+              <PlusIcon className="h-4 w-4 mr-2" />
+              Add Slot
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Accordion type="single" collapsible className="w-full">
+        {chargers.map((charger) => {
+          const chargerSlots = slots.filter(slot => slot.chargerId === charger.id);
+          return (
+            <AccordionItem key={charger.id} value={charger.id.toString()}>
+              <AccordionTrigger className="px-4">
+                <div className="flex justify-between w-full pr-4">
+                  <span className="font-semibold">Charger {charger.id} - {charger.type}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {chargerSlots.length} time slots
+                  </span>
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <Card>
+                  <CardContent className="p-4">
+                    <div className="space-y-4">
+                      {chargerSlots.map((slot) => (
+                        <div key={slot.id} className="flex items-center justify-between p-4 border rounded-lg">
+                          <div className="flex items-center gap-4">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">{slot.startTime}</span>
+                              <span>-</span>
+                              <span className="font-medium">{slot.endTime}</span>
+                            </div>
+                            <Label
+                              className={slot.isAvailable ? "text-green-500" : "text-red-500"}
+                            >
+                              {slot.isAvailable ? "Available" : "Unavailable"}
+                            </Label>
+                          </div>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => onToggleAvailability(slot.id)}
+                            >
+                              {slot.isAvailable ? "Set Unavailable" : "Set Available"}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => onRemoveSlot(slot.id)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                      {chargerSlots.length === 0 && (
+                        <div className="text-center py-8 text-muted-foreground">
+                          No time slots defined for this charger.
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              </AccordionContent>
+            </AccordionItem>
+          );
+        })}
+      </Accordion>
+    </div>
+  );
+} 

--- a/src/pages/station_operator/StationOperatorPage.tsx
+++ b/src/pages/station_operator/StationOperatorPage.tsx
@@ -76,7 +76,6 @@ function StationOperatorPage() {
 
   // Time slot management handlers
   const handleAddTimeSlot = (slot: Omit<TimeSlot, "id">) => {
-    // TODO: Replace with actual API call
     const newSlot: TimeSlot = {
       ...slot,
       id: Math.random().toString(36).slice(2, 11), // Temporary ID generation
@@ -85,12 +84,10 @@ function StationOperatorPage() {
   };
 
   const handleRemoveTimeSlot = (slotId: string) => {
-    // TODO: Replace with actual API call
     setTimeSlots(timeSlots.filter(slot => slot.id !== slotId));
   };
 
   const handleToggleTimeSlotAvailability = (slotId: string) => {
-    // TODO: Replace with actual API call
     setTimeSlots(timeSlots.map(slot =>
       slot.id === slotId ? { ...slot, isAvailable: !slot.isAvailable } : slot
     ));

--- a/src/pages/station_operator/StationOperatorPage.tsx
+++ b/src/pages/station_operator/StationOperatorPage.tsx
@@ -31,7 +31,7 @@ function StationOperatorPage() {
         // Morning slots (8:00-12:00)
         for (let i = 0; i < 5; i++) {
           defaultSlots.push({
-            id: Math.random().toString(36).substr(2, 9),
+            id: Math.random().toString(36).slice(2, 11),
             chargerId: charger.id,
             startTime: `${8 + i}:00`,
             endTime: `${9 + i}:00`,
@@ -42,7 +42,7 @@ function StationOperatorPage() {
         // Afternoon slots (13:00-17:00)
         for (let i = 0; i < 5; i++) {
           defaultSlots.push({
-            id: Math.random().toString(36).substr(2, 9),
+            id: Math.random().toString(36).slice(2, 11),
             chargerId: charger.id,
             startTime: `${13 + i}:00`,
             endTime: `${14 + i}:00`,
@@ -79,7 +79,7 @@ function StationOperatorPage() {
     // TODO: Replace with actual API call
     const newSlot: TimeSlot = {
       ...slot,
-      id: Math.random().toString(36).substr(2, 9), // Temporary ID generation
+      id: Math.random().toString(36).slice(2, 11), // Temporary ID generation
     };
     setTimeSlots([...timeSlots, newSlot]);
   };

--- a/src/pages/station_operator/StationOperatorPage.tsx
+++ b/src/pages/station_operator/StationOperatorPage.tsx
@@ -1,16 +1,19 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { PlusIcon, AlertCircle } from "lucide-react";
+import { PlusIcon, AlertCircle, Clock } from "lucide-react";
 import { useStations } from "../../contexts/StationsContext";
 import { useChargers, ChargerStatus } from "../../contexts/ChargersContext";
 import NewChargerForm from "../../components/stations/NewChargerForm";
+import { TimeSlotManager, type TimeSlot } from "../../components/stations/TimeSlotManager";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 function StationOperatorPage() {
   const { stations } = useStations();
   const { addChargerToStation, updateChargerAvailability, chargers, fetchChargersByStation } = useChargers();
   const [showNewChargerForm, setShowNewChargerForm] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([]);
 
   useEffect(() => {
     // Fetch chargers for the station when the component mounts
@@ -18,6 +21,39 @@ function StationOperatorPage() {
       fetchChargersByStation(stations[0].id);
     }
   }, [stations, fetchChargersByStation]);
+
+  // Initialize default time slots when chargers are loaded
+  useEffect(() => {
+    if (chargers.length > 0 && timeSlots.length === 0) {
+      const defaultSlots: TimeSlot[] = [];
+      
+      chargers.forEach(charger => {
+        // Morning slots (8:00-12:00)
+        for (let i = 0; i < 5; i++) {
+          defaultSlots.push({
+            id: Math.random().toString(36).substr(2, 9),
+            chargerId: charger.id,
+            startTime: `${8 + i}:00`,
+            endTime: `${9 + i}:00`,
+            isAvailable: true
+          });
+        }
+        
+        // Afternoon slots (13:00-17:00)
+        for (let i = 0; i < 5; i++) {
+          defaultSlots.push({
+            id: Math.random().toString(36).substr(2, 9),
+            chargerId: charger.id,
+            startTime: `${13 + i}:00`,
+            endTime: `${14 + i}:00`,
+            isAvailable: true
+          });
+        }
+      });
+
+      setTimeSlots(defaultSlots);
+    }
+  }, [chargers]);
 
   const handleUpdateStatus = async (stationId: string, newStatus: ChargerStatus) => {
     try {
@@ -36,6 +72,28 @@ function StationOperatorPage() {
       console.error(err);
       setError("Failed to add charger. Please try again.");
     }
+  };
+
+  // Time slot management handlers
+  const handleAddTimeSlot = (slot: Omit<TimeSlot, "id">) => {
+    // TODO: Replace with actual API call
+    const newSlot: TimeSlot = {
+      ...slot,
+      id: Math.random().toString(36).substr(2, 9), // Temporary ID generation
+    };
+    setTimeSlots([...timeSlots, newSlot]);
+  };
+
+  const handleRemoveTimeSlot = (slotId: string) => {
+    // TODO: Replace with actual API call
+    setTimeSlots(timeSlots.filter(slot => slot.id !== slotId));
+  };
+
+  const handleToggleTimeSlotAvailability = (slotId: string) => {
+    // TODO: Replace with actual API call
+    setTimeSlots(timeSlots.map(slot =>
+      slot.id === slotId ? { ...slot, isAvailable: !slot.isAvailable } : slot
+    ));
   };
 
   return (
@@ -70,103 +128,127 @@ function StationOperatorPage() {
           </CardContent>
         </Card>
 
-        {/* Charging Stations Management */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Charging Stations</CardTitle>
-            {!showNewChargerForm && (
-              <Button size="sm" onClick={() => setShowNewChargerForm(true)}>
-                <PlusIcon className="h-4 w-4 mr-2" />
-                Add Charging Station
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent>
-            {error && (
-              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 flex items-center">
-                <AlertCircle className="w-5 h-5 mr-2" />
-                <span>{error}</span>
-              </div>
-            )}
+        {/* Main Content Tabs */}
+        <Tabs defaultValue="chargers" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="chargers">Chargers</TabsTrigger>
+            <TabsTrigger value="time-slots">
+              <Clock className="h-4 w-4 mr-2" />
+              Time Slots
+            </TabsTrigger>
+          </TabsList>
 
-            {showNewChargerForm ? (
-              <Card>
-                <CardHeader>
-                  <CardTitle>Add New Charging Station</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {stations.length > 0 && (
-                    <NewChargerForm
-                      stationId={stations[0].id ?? 0}
-                      onSubmit={handleAddCharger}
-                      onCancel={() => setShowNewChargerForm(false)}
-                    />
-                  )}
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="space-y-4">
-                {chargers.length > 0 ? (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {chargers.map((charger) => {
-                      let statusColor = "bg-red-100 text-red-800";
-                      if (charger.status === ChargerStatus.AVAILABLE) {
-                        statusColor = "bg-green-100 text-green-800";
-                      } else if (charger.status === ChargerStatus.BEING_USED) {
-                        statusColor = "bg-blue-100 text-blue-800";
-                      } else if (charger.status === ChargerStatus.UNDER_MAINTENANCE) {
-                        statusColor = "bg-yellow-100 text-yellow-800";
-                      }
-                      return (
-                        <Card key={charger.id} className="hover:shadow-lg transition-shadow">
-                          <CardContent className="p-6">
-                            <h3 className="text-lg font-semibold mb-2">Charger {charger.id}</h3>
-                            <div className="space-y-2">
-                              <p className="text-sm">
-                                <span className="font-medium">Type:</span> {charger.type}
-                              </p>
-                              <p className="text-sm">
-                                <span className="font-medium">Power:</span> {charger.power} kW
-                              </p>
-                              <p className="text-sm">
-                                <span className="font-medium">Status:</span>{" "}
-                                <span className={`inline-block px-2 py-1 rounded-full text-xs ${statusColor}`}>
-                                  {charger.status.replace(/_/g, " ").toLowerCase()}
-                                </span>
-                              </p>
-                            </div>
-                            <div className="mt-4 flex gap-2">
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => handleUpdateStatus(charger.id.toString(), ChargerStatus.UNDER_MAINTENANCE)}
-                                disabled={charger.status === ChargerStatus.UNDER_MAINTENANCE}
-                              >
-                                Set Maintenance
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => handleUpdateStatus(charger.id.toString(), ChargerStatus.AVAILABLE)}
-                                disabled={charger.status === ChargerStatus.AVAILABLE}
-                              >
-                                Set Available
-                              </Button>
-                            </div>
-                          </CardContent>
-                        </Card>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <div className="text-center py-8 text-muted-foreground">
-                    No charging stations available.
+          {/* Chargers Tab */}
+          <TabsContent value="chargers">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Charging Stations</CardTitle>
+                {!showNewChargerForm && (
+                  <Button size="sm" onClick={() => setShowNewChargerForm(true)}>
+                    <PlusIcon className="h-4 w-4 mr-2" />
+                    Add Charging Station
+                  </Button>
+                )}
+              </CardHeader>
+              <CardContent>
+                {error && (
+                  <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 flex items-center">
+                    <AlertCircle className="w-5 h-5 mr-2" />
+                    <span>{error}</span>
                   </div>
                 )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+
+                {showNewChargerForm ? (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Add New Charging Station</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      {stations.length > 0 && (
+                        <NewChargerForm
+                          stationId={stations[0].id ?? 0}
+                          onSubmit={handleAddCharger}
+                          onCancel={() => setShowNewChargerForm(false)}
+                        />
+                      )}
+                    </CardContent>
+                  </Card>
+                ) : (
+                  <div className="space-y-4">
+                    {chargers.length > 0 ? (
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {chargers.map((charger) => {
+                          let statusColor = "bg-red-100 text-red-800";
+                          if (charger.status === ChargerStatus.AVAILABLE) {
+                            statusColor = "bg-green-100 text-green-800";
+                          } else if (charger.status === ChargerStatus.BEING_USED) {
+                            statusColor = "bg-blue-100 text-blue-800";
+                          } else if (charger.status === ChargerStatus.UNDER_MAINTENANCE) {
+                            statusColor = "bg-yellow-100 text-yellow-800";
+                          }
+                          return (
+                            <Card key={charger.id} className="hover:shadow-lg transition-shadow">
+                              <CardContent className="p-6">
+                                <h3 className="text-lg font-semibold mb-2">Charger {charger.id}</h3>
+                                <div className="space-y-2">
+                                  <p className="text-sm">
+                                    <span className="font-medium">Type:</span> {charger.type}
+                                  </p>
+                                  <p className="text-sm">
+                                    <span className="font-medium">Power:</span> {charger.power} kW
+                                  </p>
+                                  <p className="text-sm">
+                                    <span className="font-medium">Status:</span>{" "}
+                                    <span className={`inline-block px-2 py-1 rounded-full text-xs ${statusColor}`}>
+                                      {charger.status.replace(/_/g, " ").toLowerCase()}
+                                    </span>
+                                  </p>
+                                </div>
+                                <div className="mt-4 flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => handleUpdateStatus(charger.id.toString(), ChargerStatus.UNDER_MAINTENANCE)}
+                                    disabled={charger.status === ChargerStatus.UNDER_MAINTENANCE}
+                                  >
+                                    Set Maintenance
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => handleUpdateStatus(charger.id.toString(), ChargerStatus.AVAILABLE)}
+                                    disabled={charger.status === ChargerStatus.AVAILABLE}
+                                  >
+                                    Set Available
+                                  </Button>
+                                </div>
+                              </CardContent>
+                            </Card>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <div className="text-center py-8 text-muted-foreground">
+                        No charging stations available.
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Time Slots Tab */}
+          <TabsContent value="time-slots">
+            <TimeSlotManager
+              chargers={chargers}
+              slots={timeSlots}
+              onAddSlot={handleAddTimeSlot}
+              onRemoveSlot={handleRemoveTimeSlot}
+              onToggleAvailability={handleToggleTimeSlotAvailability}
+            />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/src/pages/station_operator/StationOperatorPage.tsx
+++ b/src/pages/station_operator/StationOperatorPage.tsx
@@ -74,15 +74,6 @@ function StationOperatorPage() {
     }
   };
 
-  // // Time slot management handlers
-  // const handleAddTimeSlot = (slot: Omit<TimeSlot, "id">) => {
-  //   const newSlot: TimeSlot = {
-  //     ...slot,
-  //     id: Math.random().toString(36).slice(2, 11), // Temporary ID generation
-  //   };
-  //   setTimeSlots([...timeSlots, newSlot]);
-  // };
-
   const handleRemoveTimeSlot = (slotId: string) => {
     setTimeSlots(timeSlots.filter(slot => slot.id !== slotId));
   };
@@ -240,7 +231,6 @@ function StationOperatorPage() {
             <TimeSlotManager
               chargers={chargers}
               slots={timeSlots}
-              // onAddSlot={handleAddTimeSlot}
               onRemoveSlot={handleRemoveTimeSlot}
               onToggleAvailability={handleToggleTimeSlotAvailability}
             />

--- a/src/pages/station_operator/StationOperatorPage.tsx
+++ b/src/pages/station_operator/StationOperatorPage.tsx
@@ -74,14 +74,14 @@ function StationOperatorPage() {
     }
   };
 
-  // Time slot management handlers
-  const handleAddTimeSlot = (slot: Omit<TimeSlot, "id">) => {
-    const newSlot: TimeSlot = {
-      ...slot,
-      id: Math.random().toString(36).slice(2, 11), // Temporary ID generation
-    };
-    setTimeSlots([...timeSlots, newSlot]);
-  };
+  // // Time slot management handlers
+  // const handleAddTimeSlot = (slot: Omit<TimeSlot, "id">) => {
+  //   const newSlot: TimeSlot = {
+  //     ...slot,
+  //     id: Math.random().toString(36).slice(2, 11), // Temporary ID generation
+  //   };
+  //   setTimeSlots([...timeSlots, newSlot]);
+  // };
 
   const handleRemoveTimeSlot = (slotId: string) => {
     setTimeSlots(timeSlots.filter(slot => slot.id !== slotId));
@@ -240,7 +240,7 @@ function StationOperatorPage() {
             <TimeSlotManager
               chargers={chargers}
               slots={timeSlots}
-              onAddSlot={handleAddTimeSlot}
+              // onAddSlot={handleAddTimeSlot}
               onRemoveSlot={handleRemoveTimeSlot}
               onToggleAvailability={handleToggleTimeSlotAvailability}
             />


### PR DESCRIPTION
This pull request introduces a new feature for managing time slots associated with chargers in the station operator's dashboard. It includes the addition of a `TimeSlotManager` component, updates to the `StationOperatorPage` to integrate time slot management, and default initialization of time slots for chargers. Below is a summary of the most important changes:

### New Component: TimeSlotManager

* **`src/components/stations/TimeSlotManager.tsx`:** Added the `TimeSlotManager` component to manage time slots for chargers. This includes functionality for adding, removing, and toggling the availability of time slots, as well as UI elements like forms, buttons, and accordions for user interaction.

---

### Integration with StationOperatorPage

* **`src/pages/station_operator/StationOperatorPage.tsx`:** Integrated the `TimeSlotManager` component into the station operator dashboard via a new "Time Slots" tab. Added handlers (`handleAddTimeSlot`, `handleRemoveTimeSlot`, `handleToggleTimeSlotAvailability`) for managing time slots and updated the state to track `timeSlots`. [[1]](diffhunk://#diff-b70d1b4c09cad1406037135b4e7ceee8a5a6c48b0d35774595ce803befad4605L4-R16) [[2]](diffhunk://#diff-b70d1b4c09cad1406037135b4e7ceee8a5a6c48b0d35774595ce803befad4605R77-R98) [[3]](diffhunk://#diff-b70d1b4c09cad1406037135b4e7ceee8a5a6c48b0d35774595ce803befad4605R239-R251)

---

### Default Time Slot Initialization

* **`src/pages/station_operator/StationOperatorPage.tsx`:** Added logic to initialize default time slots for chargers when they are loaded. Default slots include predefined morning and afternoon time ranges.

---

### UI Enhancements

* **`src/pages/station_operator/StationOperatorPage.tsx`:** Updated the main content layout to use tabs, allowing users to switch between "Chargers" and "Time Slots" views. Added a clock icon to visually distinguish the "Time Slots" tab.