### PR TITLE
remove 'Add station' form operator

### DIFF
--- a/src/components/stations/StationsList.tsx
+++ b/src/components/stations/StationsList.tsx
@@ -31,12 +31,14 @@ interface StationsListProps {
   stations: Station[];
   onAddStation: () => void;
   isLoading?: boolean;
+  canAddStation?: boolean;
 }
 
 const StationsList: FC<StationsListProps> = ({
   stations,
   onAddStation,
   isLoading = false,
+  canAddStation = false,
 }) => {
   const navigate = useNavigate();
   const { updateStation, deleteStation } = useStations();
@@ -70,25 +72,28 @@ const StationsList: FC<StationsListProps> = ({
   }
 
   return (
-    <div className="container mx-auto  ">
+    <div className="container mx-auto">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Charging Stations</h1>
-        <Button
-          onClick={onAddStation}
-          className="flex items-center gap-2"
-          disabled={isLoading}
-        >
-          <Plus className="w-5 h-5" />
-          Add Station
-        </Button>
+        {canAddStation && (
+          <Button
+            onClick={onAddStation}
+            className="flex items-center gap-2"
+            disabled={isLoading}
+          >
+            <Plus className="w-5 h-5" />
+            Add Station
+          </Button>
+        )}
       </div>
-
       {stations.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-muted-foreground mb-4">
             No charging stations found
           </p>
-          <Button onClick={onAddStation}>Register Your First Station</Button>
+          {canAddStation && (
+            <Button onClick={onAddStation}>Register Your First Station</Button>
+          )}
         </div>
       ) : (
         <div className="grid gap-4">

--- a/src/pages/manage_stations/StationsPage.tsx
+++ b/src/pages/manage_stations/StationsPage.tsx
@@ -6,6 +6,7 @@ import { useState, type FC } from "react";
 import { useStations } from "../../contexts/StationsContext";
 import type { StationFormData } from "../../contexts/StationsContext";
 import { AlertCircle } from "lucide-react";
+import { useAuth } from "../../contexts/AuthContext";
 
 interface StationListItem {
   id: string;
@@ -21,6 +22,7 @@ interface StationListItem {
 }
 
 const StationsPage: FC = () => {
+  const { user } = useAuth();
   const [showNewStationForm, setShowNewStationForm] = useState(false);
   const [selectedStationId, setSelectedStationId] = useState<string | null>(
     null
@@ -93,6 +95,7 @@ const StationsPage: FC = () => {
             stations={stationsWithStringIds}
             onAddStation={() => setShowNewStationForm(true)}
             isLoading={loading}
+            canAddStation={user?.userType === "ADMIN"}
           />
         )}
       </div>


### PR DESCRIPTION
This pull request introduces conditional logic to control the visibility of "Add Station" functionality based on user type and updates the `StationsList` and `StationsPage` components accordingly. The most important changes include adding a new `canAddStation` prop to `StationsListProps`, integrating user authentication context in `StationsPage`, and ensuring the "Add Station" button is displayed only for admin users.

### Updates to `StationsList` component:

* Added a new optional `canAddStation` prop to `StationsListProps`, defaulting to `false`. This prop determines whether the "Add Station" button should be displayed.
* Updated the "Add Station" button and empty state message to be conditionally rendered based on the `canAddStation` prop. [[1]](diffhunk://#diff-15b509a8baa596c4a1114becc27558affb0d2f1278d0b2d7ee1696ce6c88989bR78) [[2]](diffhunk://#diff-15b509a8baa596c4a1114becc27558affb0d2f1278d0b2d7ee1696ce6c88989bR87-R96)

### Updates to `StationsPage` component:

* Imported `useAuth` from `AuthContext` to access user authentication details.
* Added logic to pass the `canAddStation` prop to `StationsList`, setting it to `true` only if the logged-in user has an `ADMIN` user type. [[1]](diffhunk://#diff-578447a0683039bf0c2d221661c12e8454e013b170e3c620ee5d21e2f85e91fcR25) [[2]](diffhunk://#diff-578447a0683039bf0c2d221661c12e8454e013b170e3c620ee5d21e2f85e91fcR98)